### PR TITLE
Tweak for v0.14 Compatibile layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.1
+  - 2.1
+  - 2.2
+  - 2.3.4
+  - 2.4.1
+before_install:
+  - gem update bundler

--- a/fluent-plugin-free.gemspec
+++ b/fluent-plugin-free.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "test-unit", "~> 3.2.0"
   spec.add_runtime_dependency "fluentd"
 end

--- a/lib/fluent/plugin/in_free.rb
+++ b/lib/fluent/plugin/in_free.rb
@@ -3,6 +3,11 @@ require 'fluent/input'
 class Fluent::FreeInput < Fluent::Input
   Fluent::Plugin.register_input('free', self)
 
+  # Define `router` method of v0.12 to support v0.10 or earlier
+  unless method_defined?(:router)
+    define_method("router") { Fluent::Engine }
+  end
+
   config_param :interval, :time,   :default => nil
   config_param :unit,     :string, :default => 'mega'
   config_param :mode,     :string, :default => nil
@@ -37,11 +42,12 @@ class Fluent::FreeInput < Fluent::Input
   def shutdown
     @thread.terminate
     @thread.join
+    super
   end
 
   def run
     loop do
-      Fluent::Engine.emit(@tag, Fluent::Engine.now, get_free_info)
+      router.emit(@tag, Fluent::Engine.now, get_free_info)
       sleep @tick
     end
   end

--- a/lib/fluent/plugin/in_free.rb
+++ b/lib/fluent/plugin/in_free.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 class Fluent::FreeInput < Fluent::Input
   Fluent::Plugin.register_input('free', self)
 


### PR DESCRIPTION
I've found that this plugin is not ready to work with Fluentd v0.14 Compatible layer.
I tried to be able to run test cases with Fluentd v0.14.

Could you check these patches?

Thanks in advance.