### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.1
+  - 2.1
+  - 2.2
+  - 2.3.4
+  - 2.4.1
+before_install:
+  - gem update bundler

--- a/fluent-plugin-free.gemspec
+++ b/fluent-plugin-free.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", "~> 3.2.0"
-  spec.add_runtime_dependency "fluentd"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
 end

--- a/fluent-plugin-free.gemspec
+++ b/fluent-plugin-free.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "test-unit", "~> 3.2.0"
   spec.add_runtime_dependency "fluentd"
 end

--- a/lib/fluent/plugin/in_free.rb
+++ b/lib/fluent/plugin/in_free.rb
@@ -5,11 +5,6 @@ class Fluent::Plugin::FreeInput < Fluent::Plugin::Input
 
   helpers :timer
 
-  # Define `router` method of v0.12 to support v0.10 or earlier
-  unless method_defined?(:router)
-    define_method("router") { Fluent::Engine }
-  end
-
   config_param :interval, :time,   :default => nil
   config_param :unit,     :string, :default => 'mega'
   config_param :mode,     :string, :default => nil
@@ -39,10 +34,6 @@ class Fluent::Plugin::FreeInput < Fluent::Plugin::Input
   def start
     super
     timer_execute(:in_free_timer, @tick, &method(:run))
-  end
-
-  def shutdown
-    super
   end
 
   def run

--- a/lib/fluent/plugin/in_free.rb
+++ b/lib/fluent/plugin/in_free.rb
@@ -1,7 +1,9 @@
-require 'fluent/input'
+require 'fluent/plugin/input'
 
-class Fluent::FreeInput < Fluent::Input
+class Fluent::Plugin::FreeInput < Fluent::Plugin::Input
   Fluent::Plugin.register_input('free', self)
+
+  helpers :timer
 
   # Define `router` method of v0.12 to support v0.10 or earlier
   unless method_defined?(:router)
@@ -36,20 +38,15 @@ class Fluent::FreeInput < Fluent::Input
 
   def start
     super
-    @thread = Thread.new(&method(:run))
+    timer_execute(:in_free_timer, @tick, &method(:run))
   end
 
   def shutdown
-    @thread.terminate
-    @thread.join
     super
   end
 
   def run
-    loop do
-      router.emit(@tag, Fluent::Engine.now, get_free_info)
-      sleep @tick
-    end
+    router.emit(@tag, Fluent::Engine.now, get_free_info)
   end
 
   private

--- a/lib/fluent/plugin/in_free.rb
+++ b/lib/fluent/plugin/in_free.rb
@@ -3,6 +3,11 @@ require 'fluent/input'
 class Fluent::FreeInput < Fluent::Input
   Fluent::Plugin.register_input('free', self)
 
+  # Define `router` method of v0.12 to support v0.10 or earlier
+  unless method_defined?(:router)
+    define_method("router") { Fluent::Engine }
+  end
+
   config_param :interval, :time,   :default => nil
   config_param :unit,     :string, :default => 'mega'
   config_param :mode,     :string, :default => nil
@@ -37,11 +42,12 @@ class Fluent::FreeInput < Fluent::Input
   def shutdown
     @thread.terminate
     @thread.join
+    super
   end
 
   def run
     loop do
-      Fluent::Engine.emit(@tag, Fluent::Engine.now, get_free_info)
+      router.emit(@tag, Fluent::Engine.now, get_free_info)
       sleep @tick
     end
   end

--- a/lib/fluent/plugin/in_free.rb
+++ b/lib/fluent/plugin/in_free.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 class Fluent::FreeInput < Fluent::Input
   Fluent::Plugin.register_input('free', self)
 

--- a/test/pulugin/test_in_free.rb
+++ b/test/pulugin/test_in_free.rb
@@ -1,4 +1,5 @@
 require 'helper'
+require 'fluent/test/driver/input'
 
 class FreeInputTest < Test::Unit::TestCase
   def setup
@@ -36,7 +37,7 @@ class FreeInputTest < Test::Unit::TestCase
   ]
 
   def create_driver(conf = DEFAULT_CONFIG)
-    Fluent::Test::InputTestDriver.new(Fluent::FreeInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::FreeInput).configure(conf)
   end
 
   def test_configure_default
@@ -66,27 +67,25 @@ class FreeInputTest < Test::Unit::TestCase
   # mode => actual, unit => mega
   def test_emit1
     d = create_driver(CONFIG_EMIT1)
-    d.run do
-      sleep 3
-    end
+    d.run(expect_emits: 1)
     com_ret = `free #{d.instance.option}`
     used = com_ret.split($/)[2].split(/\s+/)[2]
     free = com_ret.split($/)[2].split(/\s+/)[3]
-    assert (d.emits[0][2]["used"].to_i - used.to_i).abs < 30
-    assert (d.emits[0][2]["free"].to_i - free.to_i).abs < 30
+    events = d.events.map{|e| e.last}.first
+    assert (events["used"].to_i - used.to_i).abs < 30
+    assert (events["free"].to_i - free.to_i).abs < 30
   end
 
   # mode => nil, unit => kilo
   def test_emit2
     d = create_driver(CONFIG_EMIT2)
-    d.run do
-      sleep 3
-    end
+    d.run(expect_emits: 1)
     com_ret = `free #{d.instance.option}`
     used = com_ret.split($/)[1].split(/\s+/)[2]
     free = com_ret.split($/)[1].split(/\s+/)[3]
-    assert (d.emits[0][2]["used"].to_i - used.to_i).abs < 30 * 1024
-    assert (d.emits[0][2]["free"].to_i - free.to_i).abs < 30 * 1024
+    events = d.events.map{|e| e.last}.first
+    assert (events["used"].to_i - used.to_i).abs < 30 * 1024
+    assert (events["free"].to_i - free.to_i).abs < 30 * 1024
   end
 
 end


### PR DESCRIPTION
Please take a look after #1 is merged.

---

I've tried to migrate to use v0.14 Input Plugin API.
This PR contains major update change.
Could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks in advance.